### PR TITLE
CONN is forcibly installed even if  it already is installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,14 @@
   - When installing features a verbose message is written if a feature is found
     to already be installed. It no longer quietly removes the feature from the
     `/FEATURES` argument.
+  - Cleaned up a bit in the tests, removed excessive piping.
   - Fixed minor typo in examples.
+  - Changes to integration tests
+    - CONN feature was temporarily removed from the instances installed by the
+      integration tests. This is due to issue #1105.
   - For SQL Server 2017 when installing feature CONN, and CONN already exist, the
     feature CONN was no longer detected. Now CONN is forcibly installed even if
     it already is installed ([issue #1105](https://github.com/PowerShell/SqlServerDsc/issues/1105)).
-  - Cleaned up a bit in the tests, removed excessive piping.
 
 ## 12.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,11 @@
   - When installing features a verbose message is written if a feature is found
     to already be installed. It no longer quietly removes the feature from the
     `/FEATURES` argument.
-  - Cleaned up a bit in the tests, removed excessive piping.
   - Fixed minor typo in examples.
-  - Changes to integration tests
-    - CONN feature was temporarily removed from the instances installed by the
-      integration tests. This is due to issue #1105.
+  - For SQL Server 2017 when installing feature CONN, and CONN already exist, the
+    feature CONN was no longer detected. Now CONN is forcibly installed even if
+    it already is installed ([issue #1105](https://github.com/PowerShell/SqlServerDsc/issues/1105)).
+  - Cleaned up a bit in the tests, removed excessive piping.
 
 ## 12.0.0.0
 

--- a/DSCResources/MSFT_SqlSetup/MSFT_SqlSetup.psm1
+++ b/DSCResources/MSFT_SqlSetup/MSFT_SqlSetup.psm1
@@ -1015,7 +1015,12 @@ function Set-TargetResource
             New-InvalidOperationException -Message $errorMessage
         }
 
-        if (-not ($getTargetResourceResult.Features.Contains($feature)))
+        <#
+            Need to override 'CONN' on SQL Server 2017 if already installed.
+            See issue #1105 for more information.
+        #>
+        if (($feature -eq 'CONN' -and $sqlVersion -in ('14')) `
+            -or (-not ($getTargetResourceResult.Features.Contains($feature))))
         {
             $featuresToInstall += "$feature,"
         }

--- a/Tests/Unit/MSFT_SqlSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlSetup.Tests.ps1
@@ -3095,6 +3095,77 @@ try
                     }
                 }
 
+                # Regression test for issue #1105
+                Context "When SQL Server version is $mockSqlMajorVersion and feature 'CONN' is already installed" {
+                    BeforeEach {
+                        Mock -CommandName Get-TargetResource -MockWith {
+                            return @{
+                                Features = 'CONN'
+                            }
+                        }
+
+                        Mock -CommandName New-SmbMapping -Verifiable
+                        Mock -CommandName Remove-SmbMapping -Verifiable
+                        Mock -CommandName Copy-ItemWithRobocopy -Verifiable
+                        Mock -CommandName Get-TemporaryFolder -MockWith $mockGetTemporaryFolder -Verifiable
+                        Mock -CommandName New-Guid -MockWith $mockNewGuid -Verifiable
+                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                        } -MockWith $mockEmptyHashtable -Verifiable
+
+                        Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
+                    }
+
+                    It 'Should set the system in the desired state when feature is SQLENGINE' {
+                        $testParameters = $mockDefaultParameters.Clone()
+                        $testParameters['Features'] = 'SQLENGINE,CONN'
+                        $testParameters += @{
+                            InstanceName = $mockDefaultInstance_InstanceName
+                            SourcePath = $mockSourcePath
+                            SQLSysAdminAccounts = 'COMPANY\User1','COMPANY\SQLAdmins'
+                        }
+
+                        # Regression testing of issue #1105.
+                        if ($mockSqlMajorVersion -in (14))
+                        {
+                            <#
+                                CONN is already installed, but since it is the
+                                SQL Server 2017 version, CONN is forcibly added
+                                to the setup Features argument.
+                            #>
+                            $mockExpectedFeatures = $testParameters.Features
+                        }
+                        else
+                        {
+                            <#
+                                CONN is already installed, so that should not be
+                                installed, so it is not added to the setup Features
+                                argument.
+                            #>
+                            $mockExpectedFeatures = $testParameters.Features -replace ',CONN'
+                        }
+
+                        $mockStartSqlSetupProcessExpectedArgument = @{
+                            Quiet = 'True'
+                            IAcceptSQLServerLicenseTerms = 'True'
+                            Action = 'Install'
+                            InstanceName = 'MSSQLSERVER'
+                            Features = $mockExpectedFeatures
+                            SQLSysAdminAccounts = 'COMPANY\sqladmin COMPANY\SQLAdmins COMPANY\User1'
+                            AGTSVCSTARTUPTYPE = 'Automatic'
+                        }
+
+                        { Set-TargetResource @testParameters } | Should -Not -Throw
+                    }
+                }
+
                 Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a default instance" {
                     BeforeEach {
                         Mock -CommandName New-SmbMapping -Verifiable


### PR DESCRIPTION
- Changes to SqlSetup
  - For SQL Server 2017 when installing feature CONN, and CONN already exist, the
    feature CONN was no longer detected. Now CONN is forcibly installed even if
    it already is installed (issue #1105).